### PR TITLE
Update python version and instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,12 +83,30 @@ existing sheet.
 
 ## (Cloud) Run
 
-As an alternative, this script can be hosted using Google Cloud Run. Deploy it
-using the following command:
+As an alternative, this script can be hosted using Google Cloud Run. 
+
+### Develop
+
+To develop locally, set an application-default credential with the requisite permissions:
+
+```
+gcloud auth application-default login \
+  --scopes https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/drive,https://www.googleapis.com/auth/spreadsheets
+```
+
+Then run the function:
+
+```
+functions-framework --target=generate_pairing
+```
+
+### Deploy
+
+Deploy it using the following command:
 
 ```
 gcloud functions deploy <CloudRun-func-name> --gen2 \
-    --runtime=python38 --source=. --entry-point=generate_pairings \
+    --runtime=python311 --source=. --entry-point=generate_pairings \
     --trigger-http \
     --region=<region> --project=<project>
 ```

--- a/swiss.py
+++ b/swiss.py
@@ -283,9 +283,9 @@ def OrderPairingsByTsp(pairings: Pairings) -> Pairings:
             weights[alpha_right, beta_right] = weights[
                 alpha_left, beta_left
             ] = PairingTransitionCost(pairings[alpha], pairings[beta][::-1])
-    tour = elkai.solve_float_matrix(weights)
+    tour = elkai.DistanceMatrix(weights).solve_tsp()
     output_pairings = []
-    for node in tour[1::2]:
+    for node in tour[1:-1:2]:
         next_pairing = pairings[(node - 1) // 2]
         if node % 2 == 0:
             next_pairing = next_pairing[::-1]


### PR DESCRIPTION
Update python version to 3.11 and instructions to run/deploy. 

Also updated solver usage to work with floats; the solver lib that works with Python 3.11 changed implementation, and no longer supports floats.